### PR TITLE
Update for symfony5, php8, latte2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,18 @@
   "description": "Latte templating engine for Symfony",
   "license": "MIT",
   "require": {
-    "php": "~7.1",
+    "php": "^7.1|^8.0",
     "nette/forms": "^3.0",
     "nette/utils": "^3.0",
     "latte/latte": "^2.5",
-    "symfony/framework-bundle": "^4.1",
-    "symfony/http-kernel": "^4.1"
+    "symfony/framework-bundle": "^4.1|^5.0",
+    "symfony/http-kernel": "^4.1|^5.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^0.12",
     "roave/security-advisories": "dev-master",
-    "symfony/security-bundle": "^4.1",
-    "symfony/translation": "^4.1"
+    "symfony/security-bundle": "^4.1|^5.0",
+    "symfony/translation": "^4.1|^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Resources/config/services/symfony_bridge.yaml
+++ b/src/Resources/config/services/symfony_bridge.yaml
@@ -16,7 +16,7 @@ services:
     ## Runtime providers
     Mangoweb\LatteBundle\SymfonyBridge\SymfonyProvider:
         tags:
-            - {name: 'latte.provider', provider_name: '_symfony'}
+            - {name: 'latte.provider', provider_name: 'symfony'}
 
     Mangoweb\LatteBundle\SymfonyBridge\SymfonyProvider\:
         resource: '../../SymfonyBridge/SymfonyProvider/*'

--- a/src/SymfonyBridge/SymfonyProvider.php
+++ b/src/SymfonyBridge/SymfonyProvider.php
@@ -4,7 +4,7 @@ namespace Mangoweb\LatteBundle\SymfonyBridge;
 
 class SymfonyProvider
 {
-	public const PREFIX = '$this->global->_symfony';
+	public const PREFIX = '$this->global->symfony';
 
 	/** @var SymfonyProvider\HttpKernelRuntimeProvider */
 	private $httpKernel;


### PR DESCRIPTION
Update composer require to allow for symfony5, php8

Rename provider, to address breaking change in Latte 2.9 (https://github.com/nette/latte/commit/0a6ec38c34579c2813d5249ac4943ee93b0b0c61)